### PR TITLE
Improve API error reporting

### DIFF
--- a/script.js
+++ b/script.js
@@ -974,7 +974,23 @@ class MeetingTranscriptionApp {
                 }
                 
                 if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
+                    let errorMessage = `HTTP error! status: ${response.status}`;
+                    try {
+                        const errorText = await response.text();
+                        try {
+                            const errorJson = JSON.parse(errorText);
+                            if (errorJson.error && errorJson.error.message) {
+                                errorMessage += ` - ${errorJson.error.message}`;
+                            } else {
+                                errorMessage += ` - ${errorText}`;
+                            }
+                        } catch (_) {
+                            errorMessage += ` - ${errorText}`;
+                        }
+                    } catch (_) {
+                        // ignore parse errors
+                    }
+                    throw new Error(errorMessage);
                 }
                 
                 return response;


### PR DESCRIPTION
## Summary
- improve error logging for API retries to show error messages when response is not OK

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6878fb599864832c8e140dc33c3323ba